### PR TITLE
`authenticate_verify_nonce` with bearer auth

### DIFF
--- a/openapi/docs/AuthenticateApi.md
+++ b/openapi/docs/AuthenticateApi.md
@@ -28,7 +28,7 @@ Name | Type | Description  | Required | Notes
 
 ### Authorization
 
-No authorization required
+[bearerAuth](../README.md#bearerAuth)
 
 ### HTTP request headers
 

--- a/openapi/src/apis/authenticate_api.rs
+++ b/openapi/src/apis/authenticate_api.rs
@@ -42,6 +42,9 @@ pub async fn authenticate_verify_nonce(
         local_var_req_builder =
             local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
     }
+    if let Some(ref local_var_token) = local_var_configuration.bearer_access_token {
+        local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+    };
     local_var_req_builder = local_var_req_builder.json(&body);
 
     let local_var_req = local_var_req_builder.build()?;


### PR DESCRIPTION
### Overview of Changes in this PR

-   codegen `authenticate_verify_nonce` with a bearer auth security scheme