### PR TITLE
GHA workflow improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           tag: v${{ steps.get_version.outputs.version }}
 
       - name: Create Release
-        if: ${{ !steps.tag_create.outputs.tag_exists }}
+        if: ${{ steps.tag_create.outputs.tag_exists != 'true' }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Overview of Changes in this PR

-   fix registry reference in workflow name
-   fix double quote escaping
-   compare step output to string

On the last bullet, there's a note [here](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs) that

> Outputs are Unicode strings

so the step output has to be compared directly to the string `'true'`, rather than treated as a boolean.