### PR TITLE
chore: use gnu-compatible sed syntax in codemod

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -14,7 +14,7 @@ remove_lines_between_markers() {
     local end_marker=$3
 
     # Use sed to remove lines between start and end markers, inclusive
-    sed -i '' -e "/$start_marker/,/$end_marker/d" "$file"
+    sed -i.bak "/$start_marker/,/$end_marker/d" "$file" && rm -f "$file.bak"
 }
 
 # Function to process a single Rust file
@@ -49,7 +49,7 @@ process_rust_file() {
     rm "$tmp_file"
 
     # Remove 'Default' from #[derive(...)] lines
-    sed -i '' -E 's/(\#\[derive\([^\)]*)Default,?\s*/\1/' "$file"
+    sed -i.bak -E 's/(\#\[derive\([^\)]*)Default,?\s*/\1/; s/,  */, /g' "$file" && rm -f "$file.bak"
 }
 
 # Function to recursively process all Rust files in a directory
@@ -90,4 +90,4 @@ echo -e "#![allow(clippy::all)]\n#![allow(dead_code)]" > "$tmpfile"
 cat ./src/openapi/mod.rs >> "$tmpfile"
 mv "$tmpfile" ./src/openapi/mod.rs
 
-sed -i '' -E 's/crate::/crate::openapi::/g' ./src/openapi/**/*.rs
+sed -i.bak -E 's/crate::/crate::openapi::/g' ./src/openapi/**/*.rs && rm -f ./src/openapi/**/*.rs.bak


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
-   make generate.sh gnu-compatible

The previous syntax worked as expected on MacOS, but not when ran in Github Actions (which uses Ubuntu as a default).

The new syntax has the same behavior on both systems.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
