### PR TITLE
feat: move operations to nested Auth and User structs

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,139 @@
+use crate::openapi::apis::configuration::Configuration;
+use crate::openapi::apis::{authenticate_api, transactions_api};
+use crate::Error;
+
+pub struct Auth {
+    pub(crate) configuration: Configuration,
+}
+
+impl Auth {
+    /// Creates a new instance of the `Auth` struct.
+    pub fn new(configuration: Configuration) -> Self {
+        Self { configuration }
+    }
+
+    /// Creates a transaction to start a user's registration process.
+    ///
+    /// # Arguments
+    ///
+    /// * `external_id` - A unique, immutable string that represents the user.
+    /// * `passkey_display_name` - The label for the user's passkey that they will see when logging in.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the transaction ID as a string or an `Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use passage_flex::PassageFlex;
+    ///
+    /// let passage_flex = PassageFlex::new(
+    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
+    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
+    /// );
+    ///
+    /// let transaction = passage_flex
+    ///     .create_register_transaction(
+    ///         "00000000-0000-0000-0000-000000000001".to_string(),
+    ///         "user@example.com".to_string(),
+    ///     )
+    ///     .await
+    ///     .unwrap();
+    /// ```
+    pub async fn create_register_transaction(
+        &self,
+        external_id: String,
+        passkey_display_name: String,
+    ) -> Result<String, Error> {
+        transactions_api::create_register_transaction(
+            &self.configuration,
+            crate::openapi::models::CreateTransactionRegisterRequest {
+                external_id,
+                passkey_display_name,
+            },
+        )
+        .await
+        .map(|response| response.transaction_id)
+        .map_err(Into::into)
+    }
+
+    /// Creates a transaction to start a user's authentication process.
+    ///
+    /// # Arguments
+    ///
+    /// * `external_id` - A unique, immutable string that represents the user.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the transaction ID as a string or an `Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use passage_flex::PassageFlex;
+    ///
+    /// let passage_flex = PassageFlex::new(
+    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
+    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
+    /// );
+    ///
+    /// let transaction = passage_flex
+    ///     .create_authenticate_transaction(
+    ///         "00000000-0000-0000-0000-000000000001".to_string(),
+    ///     )
+    ///     .await
+    ///     .unwrap();
+    /// ```
+    pub async fn create_authenticate_transaction(
+        &self,
+        external_id: String,
+    ) -> Result<String, Error> {
+        transactions_api::create_authenticate_transaction(
+            &self.configuration,
+            crate::openapi::models::CreateTransactionAuthenticateRequest { external_id },
+        )
+        .await
+        .map(|response| response.transaction_id)
+        .map_err(Into::into)
+    }
+
+    /// Verifies the nonce received from a WebAuthn registration or authentication ceremony.
+    ///
+    /// # Arguments
+    ///
+    /// * `nonce` - The nonce string to be verified.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the external ID as a string or an `Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use passage_flex::PassageFlex;
+    ///
+    /// let passage_flex = PassageFlex::new(
+    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
+    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
+    /// );
+    ///
+    /// match passage_flex.verify_nonce("01234567890123456789".to_string()).await {
+    ///     Ok(external_id) => {
+    ///         // use external_id to do things like generate and send your own auth token
+    ///     }
+    ///     Err(err) => {
+    ///         // nonce was invalid or unable to be verified
+    ///     }
+    /// }
+    /// ```
+    pub async fn verify_nonce(&self, nonce: String) -> Result<String, Error> {
+        authenticate_api::authenticate_verify_nonce(
+            &self.configuration,
+            crate::openapi::models::Nonce { nonce },
+        )
+        .await
+        .map(|response| response.external_id)
+        .map_err(Into::into)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,4 +63,5 @@ pub mod models;
 pub mod openapi;
 
 pub mod passage_flex;
+pub mod user;
 pub use passage_flex::PassageFlex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub mod models;
 #[rustfmt::skip]
 pub mod openapi;
 
+pub mod auth;
 pub mod passage_flex;
 pub mod user;
 pub use passage_flex::PassageFlex;

--- a/src/passage_flex.rs
+++ b/src/passage_flex.rs
@@ -1,12 +1,10 @@
-use crate::models::AppInfo;
+use crate::auth::Auth;
 use crate::openapi::apis::configuration::Configuration;
-use crate::openapi::apis::{apps_api, authenticate_api, transactions_api};
 use crate::user::User;
-use crate::Error;
 
 pub struct PassageFlex {
     app_id: String,
-    configuration: Configuration,
+    pub auth: Auth,
     pub user: User,
 }
 
@@ -47,13 +45,10 @@ impl PassageFlex {
             .build()
             .expect("Failed to create reqwest client for Passage");
 
+        let auth = Auth::new(configuration.clone());
         let user = User::new(configuration.clone());
 
-        let mut client = Self {
-            app_id,
-            configuration,
-            user,
-        };
+        let mut client = Self { app_id, auth, user };
         // Set the default server URL
         client.set_server_url(SERVER_URL.to_string());
 
@@ -62,164 +57,7 @@ impl PassageFlex {
 
     fn set_server_url(&mut self, server_url: String) {
         self.user.configuration.base_path = format!("{}/v1/apps/{}", server_url, self.app_id);
-        self.configuration.base_path = format!("{}/v1/apps/{}", server_url, self.app_id);
-    }
-
-    /// Retrieves information about the application.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` containing the `AppInfo` struct or an `Error`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use passage_flex::PassageFlex;
-    ///
-    /// let passage_flex = PassageFlex::new(
-    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
-    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
-    /// );
-    ///
-    /// let app_info = passage_flex.get_app().await.unwrap();
-    /// println!("{}", app_info.auth_origin);
-    /// ```
-    pub async fn get_app(&self) -> Result<Box<AppInfo>, Error> {
-        apps_api::get_app(&self.configuration)
-            .await
-            .map(|response| {
-                Box::new(AppInfo {
-                    auth_origin: response.app.auth_origin,
-                    id: response.app.id,
-                    name: response.app.name,
-                })
-            })
-            .map_err(Into::into)
-    }
-
-    /// Creates a transaction to start a user's registration process.
-    ///
-    /// # Arguments
-    ///
-    /// * `external_id` - A unique, immutable string that represents the user.
-    /// * `passkey_display_name` - The label for the user's passkey that they will see when logging in.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` containing the transaction ID as a string or an `Error`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use passage_flex::PassageFlex;
-    ///
-    /// let passage_flex = PassageFlex::new(
-    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
-    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
-    /// );
-    ///
-    /// let transaction = passage_flex
-    ///     .create_register_transaction(
-    ///         "00000000-0000-0000-0000-000000000001".to_string(),
-    ///         "user@example.com".to_string(),
-    ///     )
-    ///     .await
-    ///     .unwrap();
-    /// ```
-    pub async fn create_register_transaction(
-        &self,
-        external_id: String,
-        passkey_display_name: String,
-    ) -> Result<String, Error> {
-        transactions_api::create_register_transaction(
-            &self.configuration,
-            crate::openapi::models::CreateTransactionRegisterRequest {
-                external_id,
-                passkey_display_name,
-            },
-        )
-        .await
-        .map(|response| response.transaction_id)
-        .map_err(Into::into)
-    }
-
-    /// Creates a transaction to start a user's authentication process.
-    ///
-    /// # Arguments
-    ///
-    /// * `external_id` - A unique, immutable string that represents the user.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` containing the transaction ID as a string or an `Error`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use passage_flex::PassageFlex;
-    ///
-    /// let passage_flex = PassageFlex::new(
-    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
-    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
-    /// );
-    ///
-    /// let transaction = passage_flex
-    ///     .create_authenticate_transaction(
-    ///         "00000000-0000-0000-0000-000000000001".to_string(),
-    ///     )
-    ///     .await
-    ///     .unwrap();
-    /// ```
-    pub async fn create_authenticate_transaction(
-        &self,
-        external_id: String,
-    ) -> Result<String, Error> {
-        transactions_api::create_authenticate_transaction(
-            &self.configuration,
-            crate::openapi::models::CreateTransactionAuthenticateRequest { external_id },
-        )
-        .await
-        .map(|response| response.transaction_id)
-        .map_err(Into::into)
-    }
-
-    /// Verifies the nonce received from a WebAuthn registration or authentication ceremony.
-    ///
-    /// # Arguments
-    ///
-    /// * `nonce` - The nonce string to be verified.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` containing the external ID as a string or an `Error`.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use passage_flex::PassageFlex;
-    ///
-    /// let passage_flex = PassageFlex::new(
-    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
-    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
-    /// );
-    ///
-    /// match passage_flex.verify_nonce("01234567890123456789".to_string()).await {
-    ///     Ok(external_id) => {
-    ///         // use external_id to do things like generate and send your own auth token
-    ///     }
-    ///     Err(err) => {
-    ///         // nonce was invalid or unable to be verified
-    ///     }
-    /// }
-    /// ```
-    pub async fn verify_nonce(&self, nonce: String) -> Result<String, Error> {
-        authenticate_api::authenticate_verify_nonce(
-            &self.configuration,
-            crate::openapi::models::Nonce { nonce },
-        )
-        .await
-        .map(|response| response.external_id)
-        .map_err(Into::into)
+        self.auth.configuration.base_path = format!("{}/v1/apps/{}", server_url, self.app_id);
     }
 }
 

--- a/src/passage_flex/test.rs
+++ b/src/passage_flex/test.rs
@@ -289,7 +289,7 @@ async fn test_get_user() {
     let (app_id, passage_flex, mut server) = setup_passage_flex().await;
 
     let m1 = setup_empty_list_paginated_users_mock(&app_id, &mut server).await;
-    let invalid_result = passage_flex.get_user("invalid".to_string()).await;
+    let invalid_result = passage_flex.user.get("invalid".to_string()).await;
     m1.assert_async().await;
     assert!(invalid_result.is_err());
     assert!(matches!(invalid_result, Err(Error::UserNotFound)));
@@ -297,7 +297,7 @@ async fn test_get_user() {
     let m2 = setup_valid_list_paginated_users_mock(&app_id, &mut server).await;
     let m3 = setup_valid_get_user_mock(&app_id, &mut server).await;
 
-    let user_info = passage_flex.get_user("valid".to_string()).await.unwrap();
+    let user_info = passage_flex.user.get("valid".to_string()).await.unwrap();
     m2.assert_async().await;
     m3.assert_async().await;
     assert_eq!(user_info.external_id, "valid");
@@ -308,14 +308,18 @@ async fn test_get_devices() {
     let (app_id, passage_flex, mut server) = setup_passage_flex().await;
 
     let m1 = setup_empty_list_paginated_users_mock(&app_id, &mut server).await;
-    let invalid_result = passage_flex.get_devices("invalid".to_string()).await;
+    let invalid_result = passage_flex.user.list_devices("invalid".to_string()).await;
     m1.assert_async().await;
     assert!(invalid_result.is_err());
     assert!(matches!(invalid_result, Err(Error::UserNotFound)));
 
     let m2 = setup_valid_list_paginated_users_mock(&app_id, &mut server).await;
     let m3 = setup_valid_get_devices_mock(&app_id, &mut server).await;
-    let devices = passage_flex.get_devices("valid".to_string()).await.unwrap();
+    let devices = passage_flex
+        .user
+        .list_devices("valid".to_string())
+        .await
+        .unwrap();
     m2.assert_async().await;
     m3.assert_async().await;
     assert_eq!(devices.len(), 1);
@@ -328,6 +332,7 @@ async fn test_revoke_device() {
 
     let m1 = setup_empty_list_paginated_users_mock(&app_id, &mut server).await;
     let invalid_result = passage_flex
+        .user
         .revoke_device("invalid".to_string(), "invalid".to_string())
         .await;
     m1.assert_async().await;
@@ -337,6 +342,7 @@ async fn test_revoke_device() {
     let m2 = setup_valid_list_paginated_users_mock(&app_id, &mut server).await;
     let m3 = setup_valid_revoke_device_mock(&app_id, &mut server).await;
     let result = passage_flex
+        .user
         .revoke_device("valid".to_string(), "test_device_id".to_string())
         .await;
     m2.assert_async().await;

--- a/src/passage_flex/test.rs
+++ b/src/passage_flex/test.rs
@@ -1,3 +1,5 @@
+use crate::Error;
+
 use super::*;
 use mockito::{Matcher, Mock, Server, ServerGuard};
 
@@ -222,6 +224,7 @@ async fn test_create_register_transaction() {
         .await;
 
     let transaction_id = passage_flex
+        .auth
         .create_register_transaction("test".to_string(), "test".to_string())
         .await
         .unwrap();
@@ -244,6 +247,7 @@ async fn test_create_authenticate_transaction() {
         .await;
 
     let transaction_id = passage_flex
+        .auth
         .create_authenticate_transaction("test".to_string())
         .await
         .unwrap();
@@ -260,7 +264,7 @@ async fn test_verify_nonce() {
     .with_body(r#"{"error": "Could not verify nonce: nonce is invalid, expired, or cannot be found","code": "invalid_nonce"}"#)
     .create_async().await;
 
-    let invalid_result = passage_flex.verify_nonce("invalid".to_string()).await;
+    let invalid_result = passage_flex.auth.verify_nonce("invalid".to_string()).await;
     assert!(invalid_result.is_err());
     assert!(matches!(invalid_result, Err(Error::InvalidNonce)));
     m1.assert_async().await;
@@ -277,6 +281,7 @@ async fn test_verify_nonce() {
         .await;
 
     let external_id = passage_flex
+        .auth
         .verify_nonce("valid".to_string())
         .await
         .unwrap();
@@ -348,101 +353,4 @@ async fn test_revoke_device() {
     m2.assert_async().await;
     m3.assert_async().await;
     assert!(result.is_ok());
-}
-
-#[tokio::test]
-async fn test_get_app() {
-    let mut server = Server::new_async().await;
-    let api_key = "test_api_key";
-
-    let app_id = "invalid";
-    let mut invalid_passage = PassageFlex::new(app_id.to_string(), api_key.to_string());
-    invalid_passage.set_server_url(server.url());
-    let m1 = server
-        .mock("GET", "/v1/apps/invalid/")
-        .with_status(401)
-        .with_body(r#"{"error": "Invalid access token","code": "invalid_access_token"}"#)
-        .create_async()
-        .await;
-    let invalid_result = invalid_passage.get_app().await;
-    m1.assert_async().await;
-    assert!(invalid_result.is_err());
-    assert!(matches!(invalid_result, Err(Error::InvalidAccessToken)));
-
-    let app_id = "test_app_id";
-    let mut passage = PassageFlex::new(app_id.to_string(), api_key.to_string());
-    passage.set_server_url(server.url());
-    let m2 = server
-        .mock("GET", "/v1/apps/test_app_id/")
-        .with_status(200)
-        .with_body(
-            r#"{
-        "app": {
-            "additional_auth_origins": [],
-            "allowed_callback_urls": [],
-            "allowed_identifier": "external",
-            "allowed_logout_urls": [],
-            "application_login_uri": "",
-            "auth_fallback_method": "none",
-            "auth_fallback_method_ttl": 300,
-            "auth_methods": {
-                "magic_link": {
-                    "enabled": false,
-                    "ttl": 300,
-                    "ttl_display_unit": "s"
-                },
-                "otp": {
-                    "enabled": false,
-                    "ttl": 300,
-                    "ttl_display_unit": "s"
-                },
-                "passkeys": {
-                    "enabled": true
-                }
-            },
-            "auth_origin": "https://auth.test.com",
-            "auto_theme_enabled": true,
-            "created_at": "2021-01-01T00:00:00Z",
-            "default_language": "en",
-            "element_customization": {},
-            "element_customization_dark": {},
-            "hosted": false,
-            "hosted_subdomain": "test",
-            "hosted_theme": "auto",
-            "id": "test_app_id",
-            "id_token_lifetime": 600,
-            "layouts": {
-                "profile": [],
-                "registration": []
-            },
-            "login_url": "/",
-            "name": "Test App",
-            "passage_branding": true,
-            "profile_management": false,
-            "public_signup": false,
-            "redirect_url": "/",
-            "refresh_absolute_lifetime": 2592000,
-            "refresh_enabled": false,
-            "refresh_inactivity_lifetime": 432000,
-            "require_email_verification": false,
-            "require_identifier_verification": false,
-            "required_identifier": "external",
-            "role": "",
-            "rsa_public_key": "",
-            "secret": null,
-            "session_timeout_length": 5,
-            "technologies": [],
-            "type": "flex",
-            "user_metadata_schema": []
-        }
-    }"#,
-        )
-        .create_async()
-        .await;
-
-    let app_info = passage.get_app().await.unwrap();
-    m2.assert_async().await;
-    assert_eq!(app_info.id, "test_app_id");
-    assert_eq!(app_info.name, "Test App");
-    assert_eq!(app_info.auth_origin, "https://auth.test.com");
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,0 +1,179 @@
+use crate::models::UserInfo;
+use crate::openapi::apis::configuration::Configuration;
+use crate::openapi::apis::{user_devices_api, users_api};
+use crate::Error;
+
+pub struct User {
+    pub(crate) configuration: Configuration,
+}
+
+impl User {
+    /// Creates a new instance of the `User` struct.
+    pub fn new(configuration: Configuration) -> Self {
+        Self { configuration }
+    }
+
+    /// Get a user's ID in Passage by their external ID
+    async fn get_id(&self, external_id: String) -> Result<String, Error> {
+        let users = users_api::list_paginated_users(
+            &self.configuration,
+            Some(1),
+            Some(1),
+            None,
+            None,
+            Some(&external_id),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .map(|response| response.users)
+        .map_err(Into::into);
+
+        match users {
+            Ok(mut users) => match users.len() {
+                0 => Err(Error::UserNotFound),
+                1 => {
+                    let user = users.remove(0);
+                    Ok(user.id)
+                }
+                _ => Err(Error::Other("Multiple users found".to_string())),
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Retrieves information about a user by their external ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `external_id` - The unique, immutable ID that represents the user.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the `UserInfo` struct or an `Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use passage_flex::PassageFlex;
+    ///
+    /// let passage_flex = PassageFlex::new(
+    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
+    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
+    /// );
+    ///
+    /// let external_id = "00000000-0000-0000-0000-000000000001";
+    /// let user_info = passage_flex.get(external_id.to_string()).await.unwrap();
+    /// println!("{:?}", user_info.id);
+    /// ```
+    pub async fn get(&self, external_id: String) -> Result<Box<UserInfo>, Error> {
+        let user_id = self.get_id(external_id).await?;
+        users_api::get_user(&self.configuration, &user_id)
+            .await
+            .map(|response| {
+                Box::new(UserInfo {
+                    created_at: response.user.created_at,
+                    external_id: response.user.external_id,
+                    id: response.user.id,
+                    last_login_at: response.user.last_login_at,
+                    login_count: response.user.login_count,
+                    status: response.user.status,
+                    updated_at: response.user.updated_at,
+                    user_metadata: response.user.user_metadata,
+                    webauthn: response.user.webauthn,
+                    webauthn_devices: response.user.webauthn_devices,
+                    webauthn_types: response.user.webauthn_types,
+                })
+            })
+            .map_err(Into::into)
+    }
+
+    /// Retrieves information about a user's passkey devices.
+    ///
+    /// # Arguments
+    ///
+    /// * `external_id` - The unique, immutable ID that represents the user.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of `WebAuthnDevices` or an `Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use passage_flex::PassageFlex;
+    ///
+    /// let passage_flex = PassageFlex::new(
+    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
+    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
+    /// );
+    ///
+    /// let external_id = "00000000-0000-0000-0000-000000000001";
+    /// let passkey_devices = passage_flex.list_devices(external_id.to_string()).await.unwrap();
+    /// for device in passkey_devices {
+    ///     println!("{}", device.usage_count);
+    /// }
+    /// ```
+    pub async fn list_devices(
+        &self,
+        external_id: String,
+    ) -> Result<Vec<crate::openapi::models::WebAuthnDevices>, Error> {
+        let user_id = self.get_id(external_id).await?;
+        user_devices_api::list_user_devices(&self.configuration, &user_id)
+            .await
+            .map(|response| response.devices)
+            .map_err(Into::into)
+    }
+
+    /// Revokes a user's passkey device.
+    ///
+    /// # Arguments
+    ///
+    /// * `external_id` - The unique, immutable ID that represents the user.
+    /// * `device_id` - The ID of the device to be revoked.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing `()` or an `Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use passage_flex::PassageFlex;
+    /// use chrono::{Duration, NaiveDate, Utc};
+    ///
+    /// let passage_flex = PassageFlex::new(
+    ///     std::env::var("PASSAGE_APP_ID").unwrap(),
+    ///     std::env::var("PASSAGE_API_KEY").unwrap(),
+    /// );
+    ///
+    /// let external_id = "00000000-0000-0000-0000-000000000001";
+    /// let last_year = Utc::now().naive_utc().date() - Duration::days(365);
+    ///
+    /// let passkey_devices = passage_flex.get_devices(external_id.to_string()).await.unwrap();
+    ///
+    /// for device in passkey_devices {
+    ///     let last_login_at_parsed =
+    ///         NaiveDate::parse_from_str(&device.last_login_at, "%Y-%m-%dT%H:%M:%S%z").unwrap();
+    ///
+    ///     if last_login_at_parsed < last_year {
+    ///         if let Err(err) = passage_flex
+    ///             .revoke_device(external_id.clone(), device.id)
+    ///             .await
+    ///         {
+    ///             // device couldn't be revoked
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    pub async fn revoke_device(&self, external_id: String, device_id: String) -> Result<(), Error> {
+        let user_id = self.get_id(external_id).await?;
+        user_devices_api::delete_user_devices(&self.configuration, &user_id, &device_id)
+            .await
+            .map_err(Into::into)
+    }
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- moves auth operations under a nested `Auth` struct
- moves user operations under a nested `User` struct
- keeps the `set_server_url` func to maintain tests until they are moved to the e2e suite
- removes the `get_app` func since it doesn't really serve much purpose except for a test of the sdk without inducing any side effects

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
