### PR TITLE
fix: sync codegen output & pin codegen version

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -64,7 +64,7 @@ process_directory() {
 }
 
 # Run codegen
-docker run --rm -v "${PWD}:/local" -u $(id -u) openapitools/openapi-generator-cli:v7.11.0 generate \
+docker run --rm -v "${PWD}:/local" -u $(id -u) openapitools/openapi-generator-cli:v7.10.0 generate \
   -i "/local/$file" \
   -g rust \
   -o /local/openapi \

--- a/generate.sh
+++ b/generate.sh
@@ -64,7 +64,7 @@ process_directory() {
 }
 
 # Run codegen
-docker run --rm -v "${PWD}:/local" -u $(id -u) openapitools/openapi-generator-cli:latest generate \
+docker run --rm -v "${PWD}:/local" -u $(id -u) openapitools/openapi-generator-cli:v7.11.0 generate \
   -i "/local/$file" \
   -g rust \
   -o /local/openapi \

--- a/src/openapi/apis/authenticate_api.rs
+++ b/src/openapi/apis/authenticate_api.rs
@@ -49,12 +49,11 @@ pub async fn authenticate_verify_nonce(configuration: &configuration::Configurat
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 
     let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        let local_var_content = local_var_resp.text().await?;
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
-        let local_var_content = local_var_resp.text().await?;
         let local_var_entity: Option<AuthenticateVerifyNonceError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))

--- a/src/openapi/apis/transactions_api.rs
+++ b/src/openapi/apis/transactions_api.rs
@@ -61,12 +61,11 @@ pub async fn create_authenticate_transaction(configuration: &configuration::Conf
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 
     let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        let local_var_content = local_var_resp.text().await?;
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
-        let local_var_content = local_var_resp.text().await?;
         let local_var_entity: Option<CreateAuthenticateTransactionError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))
@@ -93,12 +92,11 @@ pub async fn create_register_transaction(configuration: &configuration::Configur
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 
     let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        let local_var_content = local_var_resp.text().await?;
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
-        let local_var_content = local_var_resp.text().await?;
         let local_var_entity: Option<CreateRegisterTransactionError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))

--- a/src/openapi/apis/user_devices_api.rs
+++ b/src/openapi/apis/user_devices_api.rs
@@ -56,11 +56,11 @@ pub async fn delete_user_devices(configuration: &configuration::Configuration, u
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 
     let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
     } else {
-        let local_var_content = local_var_resp.text().await?;
         let local_var_entity: Option<DeleteUserDevicesError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))
@@ -87,12 +87,11 @@ pub async fn list_user_devices(configuration: &configuration::Configuration, use
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 
     let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        let local_var_content = local_var_resp.text().await?;
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
-        let local_var_content = local_var_resp.text().await?;
         let local_var_entity: Option<ListUserDevicesError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))

--- a/src/openapi/apis/users_api.rs
+++ b/src/openapi/apis/users_api.rs
@@ -57,12 +57,11 @@ pub async fn get_user(configuration: &configuration::Configuration, user_id: &st
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 
     let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        let local_var_content = local_var_resp.text().await?;
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
-        let local_var_content = local_var_resp.text().await?;
         let local_var_entity: Option<GetUserError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))
@@ -122,12 +121,11 @@ pub async fn list_paginated_users(configuration: &configuration::Configuration, 
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 
     let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        let local_var_content = local_var_resp.text().await?;
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
-        let local_var_content = local_var_resp.text().await?;
         let local_var_entity: Option<ListPaginatedUsersError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))


### PR DESCRIPTION
### Overview of Changes in this PR

-   pin the openapi-generator image to last used released minor version

This ensures more predictable code generation by preventing unintended changes from upstream updates.

Long-term, we could introduce scheduled runs using the [latest-release](https://hub.docker.com/r/openapitools/openapi-generator-cli/tags) tag. For now, keeping the version fixed helps maintain consistency when propagating schema changes.

We can still manually update the version as needed to pull in major fixes or features.